### PR TITLE
Update readme.adoc

### DIFF
--- a/admission-policy/readme.adoc
+++ b/admission-policy/readme.adoc
@@ -61,8 +61,7 @@ Run `kops edit <cluster-name>` and specify:
       - PersistentVolumeLabel
       - DefaultStorageClass
       - DefaultTolerationSeconds
-      - MutatingAdmissionWebhook
-      - ValidatingAdmissionWebhook
+      - GenericAdmissionWebhook
       - ResourceQuota
     runtimeConfig:
       admissionregistration.k8s.io/v1alpha1: "true"
@@ -80,21 +79,6 @@ kops update <clustername>
 
 First, create the required OpenSSL configuration files:
 
-*client.conf*
-```bash
-[req]
-req_extensions = v3_req
-distinguished_name = req_distinguished_name
-[req_distinguished_name]
-[ v3_req ]
-basicConstraints = CA:FALSE
-keyUsage = nonRepudiation, digitalSignature, keyEncipherment
-extendedKeyUsage = clientAuth, serverAuth
-subjectAltName = @alt_names
-[alt_names]
-DNS.1 = opa.opa.cluster.svc.local
-```
-
 *server.conf*
 ```bash
 [req]
@@ -105,14 +89,9 @@ distinguished_name = req_distinguished_name
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, serverAuth
-subjectAltName = @alt_names
-[alt_names]
-DNS.1 = opa.opa.cluster.svc.local
 ```
 
-IMPORTANT: The subjectAltName/IP address in the certificate MUST match the one configured on the Kubernetes Service.
-
-Now generate the CA and client/server key pairs.
+Now generate the CA and server key pair.
 
 ```bash
 # Create a certificate authority
@@ -120,14 +99,10 @@ openssl genrsa -out ca.key 2048
 openssl req -x509 -new -nodes -key ca.key -days 100000 -out ca.crt -subj "/CN=admission_ca"
 
 # Create a server certiticate
+# IMPORTANT: the CN must match the name of the service used to expose the external admission controller.
 openssl genrsa -out server.key 2048
-openssl req -new -key server.key -out server.csr -subj "/CN=admission_server" -config server.conf
+openssl req -new -key server.key -out server.csr -subj "/CN=opa.opa.svc" -config server.conf
 openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 100000 -extensions v3_req -extfile server.conf
-
-# Create a client certiticate
-openssl genrsa -out client.key 2048
-openssl req -new -key client.key -out client.csr -subj "/CN=admission_client" -config client.conf
-openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 100000 -extensions v3_req -extfile client.conf
 ```
 
 === 2.2: Deploy OPA on Kubernetes
@@ -203,9 +178,11 @@ spec:
               mountPath: /certs
               name: opa-server
         - name: kube-mgmt
-          image: openpolicyagent/kube-mgmt:0.4
+          image: openpolicyagent/kube-mgmt:0.5
           args:
             - "--replicate=v1/pods"
+            - "--pod-name=$(MY_POD_NAME)"
+            - "--pod-namespace=$(MY_POD_NAMESPACE)"
             - "--register-admission-controller"
             - "--admission-controller-ca-cert-file=/certs/ca.crt"
             - "--admission-controller-service-name=opa"
@@ -215,6 +192,10 @@ spec:
               mountPath: /certs
               name: opa-ca
           env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: MY_POD_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Made a few changes...

1) revert to old GenericAdmissionWebhook admission controller name in kops config
2) use kube-mgmt v0.5 which sets up links between the pod and admission controller registration so the latter is GCed properly
3) updated certificate generation step to set CN field in certificate (it seems this has to line up with the admission controller service.)